### PR TITLE
docs: add activitywatch-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more, see the [Watchers page](https://docs.activitywatch.net/en/latest/watch
 
  - [aw-sync](https://github.com/ActivityWatch/aw-server-rust/tree/master/aw-sync), the official sync-with-folder/bring-your-own-sync solution for ActivityWatch
  - [aw-sync-suite](https://github.com/phrp720/aw-sync-suite), a centralized sync solution backed by Prometheus and visualized with Grafana, by @phrp720
- - [activitywatch-exporter](https://github.com/rare-magma/activitywatch-exporter), CLI tool that uploads the ActivityWatch data from the aw-server API to influxdb on a daily basis
+ - [activitywatch-exporter](https://github.com/rare-magma/activitywatch-exporter), CLI tool that uploads the ActivityWatch data from the aw-server API to InfluxDB on a daily basis
 
 # Videos :tv:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For more, see the [Watchers page](https://docs.activitywatch.net/en/latest/watch
 
  - [aw-sync](https://github.com/ActivityWatch/aw-server-rust/tree/master/aw-sync), the official sync-with-folder/bring-your-own-sync solution for ActivityWatch
  - [aw-sync-suite](https://github.com/phrp720/aw-sync-suite), a centralized sync solution backed by Prometheus and visualized with Grafana, by @phrp720
+ - [activitywatch-exporter](https://github.com/rare-magma/activitywatch-exporter), CLI tool that uploads the ActivityWatch data from the aw-server API to influxdb on a daily basis
 
 # Videos :tv:
 


### PR DESCRIPTION
I've created a CLI tool that uploads the ActivityWatch data from the aw-server API to influxdb on a daily basis so I though I'd share it here since more people might find it useful
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `activitywatch-exporter` CLI tool to `README.md` for daily ActivityWatch data uploads to InfluxDB.
> 
>   - **Documentation**:
>     - Adds `activitywatch-exporter` to `README.md`, a CLI tool for uploading ActivityWatch data from `aw-server` API to InfluxDB daily.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Fawesome-activitywatch&utm_source=github&utm_medium=referral)<sup> for 793ec30cc13f6412d6fd064043c3ec2aca35067f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->